### PR TITLE
Clarify optional LinkedIn credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,17 @@ A self‑contained, free BDR automation system using:
    pip install -r requirements.txt
    playwright install
    ```
-5. **Create `config.yaml`** by copying `config.example.yaml` and filling in your own credentials, search URLs, messaging seeds, and Google Sheets settings.
+5. **Create `config.yaml`** by copying `config.example.yaml` and filling in your
+   own settings. The LinkedIn `username` and `password` values are optional when
+   you log in manually through the dashboard. They are only needed for
+   headless, automated runs of the scripts.
 6. **Run the Streamlit dashboard**:
    ```bash
    streamlit run app.py
    ```
-   Then click **Login to LinkedIn** in the app and complete authentication before running other tasks.
+   Then click **Login to LinkedIn** in the app and complete authentication before
+   running other tasks. If you use this manual login flow, the LinkedIn username
+   and password fields in `config.yaml` can be left blank.
 
 ## Usage
 

--- a/app.py
+++ b/app.py
@@ -31,8 +31,16 @@ config = load_config()
 st.title("Free BDR Pipeline Dashboard")
 
 with st.expander("⚙️ Configuration"):
-    linkedin_user = st.text_input("LinkedIn Username", value=config.get("linkedin", {}).get("username", ""))
-    linkedin_pass = st.text_input("LinkedIn Password", type="password")
+    linkedin_user = st.text_input(
+        "LinkedIn Username",
+        value=config.get("linkedin", {}).get("username", ""),
+        help="Optional. Only needed for automated login",
+    )
+    linkedin_pass = st.text_input(
+        "LinkedIn Password",
+        type="password",
+        help="Optional. Only needed for automated login",
+    )
     searches_raw   = st.text_area(
         "SalesNav Searches (name|url per line)",
         value="\n".join([f"{s['name']}|{s['url']}" for s in config.get("linkedin", {}).get("searches", [])])

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,5 +1,7 @@
 # Example configuration for Free BDR Pipeline
 linkedin:
+  # Username and password are only required for automated headless runs.
+  # They can be omitted when logging in manually via the dashboard.
   username: "your_email@example.com"
   password: "YOUR_LINKEDIN_PASSWORD"
   searches:

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,7 @@
 # Copy this template and fill in your details
 linkedin:
+  # Username and password are only needed when running modules headlessly.
+  # Leave them blank if you log in manually via the dashboard.
   username: "your_email@example.com"
   password: "YOUR_LINKEDIN_PASSWORD"
   searches:


### PR DESCRIPTION
## Summary
- clarify in the docs that LinkedIn credentials are optional when logging in manually
- mark the credentials as optional in the Streamlit app
- note optional credentials in example and default configs

## Testing
- `python -m py_compile app.py modules/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685f01bb00208330b52e0774131ce738