### PR TITLE
Fix credentials path reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ __pycache__/
 venv/
 leads.db
 config.yaml
-datafiles/focus-invention-251008-53ba8c8d891e.json
+# Ignore actual credentials stored in the datafiles directory
+datafiles/*.json

--- a/README.md
+++ b/README.md
@@ -66,7 +66,11 @@ For automation, schedule individual module scripts under `modules/` via cron or 
 1. Create a Google Cloud project and enable the Google Sheets API.
 2. Generate a service account and download its credentials JSON file.
 3. Share your spreadsheet with the service account email.
-4. Set `gsheets.creds_json`, `gsheets.spreadsheet_id`, and the worksheet names (`leads_ws`, `report_ws`) in `config.yaml` accordingly. Ensure the path in `gsheets.creds_json` points to a valid JSON key file on the machine running the app.
+4. Place the downloaded credentials file in the `datafiles/` directory and
+   set `gsheets.creds_json` to that relative path (e.g.
+   `datafiles/google-credentials.json`) in `config.yaml`.
+   Also set `gsheets.spreadsheet_id` and worksheet names (`leads_ws`,
+   `report_ws`).
 
 ## License & Usage
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -23,7 +23,7 @@ seeds:
   connection: "Hi {{FirstName}}, I noticed…"
   followup: "Hello {{FirstName}}, just checking…"
 gsheets:
-  creds_json: "path/to/google-creds.json"
+  creds_json: "datafiles/google-credentials.json"
   spreadsheet_id: "GOOGLE_SHEET_ID"
   leads_ws: "Leads"
   report_ws: "Report"

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 gsheets:
-  creds_json: /Users/infoobjects/Tools/Test/datafiles/focus-invention-251008-53ba8c8d891e.json
+  creds_json: datafiles/google-credentials.json
   leads_ws: Leads
   report_ws: Report
   spreadsheet_id: 1CZh1XEXKuqyZYkOAfgMtVvNYzcvv_7zY84z1N6oueIQ

--- a/datafiles/README.md
+++ b/datafiles/README.md
@@ -1,0 +1,3 @@
+This directory should contain your Google service account credentials JSON file used for accessing Google Sheets.
+Place the file here and update `gsheets.creds_json` in `config.yaml` to point to it, e.g. `datafiles/google-credentials.json`.
+The credentials file itself should not be committed to version control.


### PR DESCRIPTION
## Summary
- ignore any creds json files in datafiles
- document Google credentials location
- update config examples to use new datafiles path
- add placeholder README under `datafiles`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68659e468e5c83308915d55e6d20d825